### PR TITLE
Suggestions for clarity & formatting of JOSS draft

### DIFF
--- a/joss/paper.md
+++ b/joss/paper.md
@@ -43,11 +43,11 @@ $80-90 \,\%$ of the total north-south integrated vapor transport
 water source for some water-stressed areas [@Dettinger2011;
 @Dettinger2013; @Rutz2012] and as a potential trigger for floods
 [@Lavers2012; @Lavers2013; @Neiman2008; @Moore2012], has granted it
-increasing attentions among the research community.  And their
-long-term change in a warming climate also stands as pressing research
+increasing attention among the research community.  Their
+long-term change in a warming climate also stands as a pressing research
 question. However, an important prerequisite to answer such questions
 is a robust and consistent detection method. As meteorologists and
-climatologist often deal with observational or simulation data in
+climatologists often deal with observational or simulation data in
 large sizes, an algorithmic method can ensure better efficiency,
 consistency and objectivity compared with human
 identification.
@@ -55,7 +55,7 @@ identification.
 In many existing applications, a magnitude thresholding approach is used. For
 instance, @Ralph2004, @Neiman2008, @Hagos2015 and @Dettinger2011 identified ARs
 by first locating regions where the Integrated Water Vapor (IWV) is greater
-than $20\, mm$.  A $250 \, kg/m/s$ threshold on the Integrated Vapor Transport
+than $20\, mm$.  A $250 \, kg/(m \cdot s)$ threshold on the Integrated Vapor Transport
 (IVT) was used by @Rutz2014 and @Rutz2015.  However, an implicit assumption
 with this magnitude thresholding approach is that the atmospheric moisture
 level stays unchanged throughout the analysis period.  Such an assumption may
@@ -84,12 +84,12 @@ identification of the strong mid-latitude AR-related moisture transports, and
 longer AR track durations. The detailed analysis has been accepted by the
 journal of Atmosphere and is now in production.
 
-The *IPART* package includes a collection of Python functions/classes designed
+The `IPART` package includes a collection of Python functions/classes designed
 for an analysis workflow covering the detection of ARs, the simplification of
 the AR's geographical location, to the subsequent tracking through time.  The
 algorithms are implemented using the Python programming language as a wrapper
-to some well-established numeric packages including *numpy* ,*scikit-image* and
-*networkx* etc..  The input and output data use the NetCDF format, an industry
+to some well-established numeric packages including `numpy`, `scikit-image` and
+`networkx` etc.  The input and output data use the NetCDF format, an industry
 standard in the geoscience field. Optional graphical outputs can also be saved,
 making it suitable for production usage and educational purposes as well.  A
 series of [Jupyter notebooks](https://github.com/ihesp/IPART/tree/master/notebooks) are also
@@ -103,8 +103,7 @@ production scripts.
 The AR detection algorithm is inspired and modified from the image
 processing algorithm *Top-hap by Reconstruction (THR)*, which consists
 of subtracting from the original image a *greyscale reconstruction by
-dilation* image.  Some more details of the THR algorithm and its
-applications can be found in this work of [@Vincent1993].
+dilation* image [@Vincent1993].
 
 In the context of AR detection, the greyscale image in question is the
 non-negative IVT distribution, denoted as $I$.  The greyscale
@@ -113,9 +112,9 @@ component, denoted as $\delta(I)$.  The difference $I - \delta(I)$
 gives the transient IVT component, from which AR candidates are
 searched. \autoref{fig:thr} shows this decomposition process.  It
 could be seen that after this separation of background/transient components,
-it comes trivial to locate AR-like features.
+it becomes trivial to locate AR-like features.
 
-![(a) The IVT field in kg/m/s at 1984-01-26 00:00 UTC over the North Hemisphere. (b) the IVT reconstruction field ($\delta(I)$) at the same time point. (c) the IVT anomaly field ($I-\delta(I)$) from the THR process at the same time point.\label{fig:thr}](fig3.png)
+![(a) The IVT field in $kg/(m \cdot s)$ at 1984-01-26 00:00 UTC over the North Hemisphere. (b) the IVT reconstruction field ($\delta(I)$) at the same time point. (c) the IVT anomaly field ($I-\delta(I)$) from the THR process at the same time point.\label{fig:thr}](fig3.png)
 
 After locating ARs at various time steps, a single curve is sought for
 each AR as a summary of its location. A directed planar graph model
@@ -124,23 +123,25 @@ algorithm is used to find this "AR axis". Further details can be found
 in the [documentation page](https://ar-tracker.readthedocs.io/en/latest/Find-AR-axis.html).
 
 
-Lastly, a [modified Hausdorff distance definition](https://ar-tracker.readthedocs.io/en/latest/Track-ARs.html) is used as inter-AR
+Lastly, a [modified Hausdorff distance definition](https://ar-tracker.readthedocs.io/en/latest/Track-ARs.html) is used as an inter-AR
 distance estimate, and an exclusive nearest neighbor approach is used to link
 ARs at consecutive time points. \autoref{fig:track} shows an
-example of this tracking process. A black-to-yellow color scheme is used to
-indicate this AR's evolution.
+example of this tracking process.
 
-![Locations of a track labelled "198424" found in year 1984. Black to yellow color scheme indicates the evolution.\label{fig:track}](ar_track_198424.png)
+![Locations of a track labelled "198424" found in year 1984. A color scheme
+of black to yellow through purple indicates the evolution,
+where black curves represent the AR at earlier times and yellow curves at
+later times.\label{fig:track}](ar_track_198424.png)
 
 
 # External libraries used
 
-Manipulation of the NetCDF data is achieved using the *CDAT* [@CDAT],
-*numpy* [@numpy] and *scipy* [@scipy] packages.
-Detection process utilizes the image-processing package *scikit-image* [@scikit-image].
-AR axis finding process utilizes the *networkx* package [@networkx].
-Generated outputs are further manipulated with *pandas* [@pandas] and
-displayed using *matplotlib* [@matplotlib].
+Manipulation of the NetCDF data is achieved using the `CDAT` [@CDAT],
+`numpy` [@numpy] and `scipy` [@scipy] packages.
+The detection process utilizes the image-processing package `scikit-image` [@scikit-image].
+The AR axis finding process utilizes the `networkx` package [@networkx].
+Generated outputs are further manipulated with `pandas` [@pandas] and
+displayed using `matplotlib` [@matplotlib].
 
 
 # Acknowledgements
@@ -151,10 +152,9 @@ This work is also supported by the National Science Foundation of China (NSFC) w
 grant No. 41490644 (41490640). This is a collaborative project between the
 Ocean University of China (OUC), Texas A\&M University (TAMU) and the National
 Center for Atmospheric Research (NCAR) and completed through the International
-Laboratory for High Resolution Earth System Prediction (iHESP)- a collaboration
+Laboratory for High Resolution Earth System Prediction (iHESP) - a collaboration
 by the Qingdao National Laboratory for Marine Science and Technology
-Development Center, Texas A&M University, and the National Center for
-Atmospheric Research.  We also received support from the
+Development Center, Texas A&M University, and NCAR.  We also received support from the
 NSFC grant \#41776013, and National Key Research and Development Program
 of China grant 2017YFC1404100 and 2017YFC1404101.
 


### PR DESCRIPTION
Towards my JOSS review (openjournals/joss-reviews#2407) & regarding your draft paper, there are some minor issues I have picked up on. It is simpler to indicate these via a PR, though I do not mind at all if you prefer to implement any changes such as those suggested here yourself (in which case, let me know & close this).

#### Clarifications:

* with units, I suggest using ``kg/(m * s)`` rather than ``kg/m/s`` as you quote at present, as the latter could easily be interpreted as ``kg/(m/s)`` i.e. ``kg*s/m`` i.e. ``kg * m**-1 * s`` whereas I believe you mean ``kg * m**-1 * s**-1`` e.g. in line with the units for the data variables in the datasets from the notebooks in the repo;
* the caption of Figure 2:
    * states "Black to yellow color scheme indicates the evolution." but it is not clear from just that which of the two colours represents the AR at earlier times (hence whether the AR starts or ends over Europe), so I suggest explicitly stating which;
    * it would be best to mention that the colour scheme includes a purple-like colour, not just black sequentially changing to yellow.

#### Formatting fixes or conventions:

* abiding by the JOSS convention of back ticks around package names, rather than italicisation (`` `package` `` not ``*package*`` etc);
* adding in some words like ``a(n)`` and ``the`` that seem missing in some cases.

#### Reducing duplication

These are subjective, but will avoid repetition and make the paper more concise, so I recommend you apply something similar to these. But each is optional.

* I think it is more concise to just refer to 'NCAR' instead in:

    > "and the National Center for Atmospheric Research"
    
    as that acronym has already been introduced in a previous sentence;
* I don't think it is necessary to state:

    > Some more details of the THR algorithm and its applications can be found in this work of [@Vincent1993].

    as the reference implies that further detail can be found there. So having the reference alone is sufficient in my opinion.