### PR TITLE
JOSS paper: force BibTeX to preserve capitalisation

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -108,7 +108,7 @@
 @InProceedings{networkx,
   author =       {Aric A. Hagberg and Daniel A. Schult and Pieter J. Swart},
   title =        {Exploring Network Structure, Dynamics, and Function using NetworkX},
-  booktitle =   {Proceedings of the 7th Python in Science Conference},
+  booktitle =   {Proceedings of the 7th {Python} in {Science} {Conference}},
   pages =     {11 - 15},
   address = {Pasadena, CA USA},
   year =      {2008},


### PR DESCRIPTION
Minor formatting-related change to fix capitalisation on the `networkx` reference for your JOSS software paper (openjournals/joss-reviews#2407). 

Sometimes BibTeX converts to lower-case, as in this case, but you can prevent this by wrapping words or characters in braces. I've used [the Whedon paper preview service](https://whedon.theoj.org/) to check this works on my own branch.