### PR TITLE
Docs: fix typo in 'Detect ARs' page heading

### DIFF
--- a/docs/Detect-ARs.rst
+++ b/docs/Detect-ARs.rst
@@ -153,7 +153,7 @@ The rows of ``ardf`` are different AR records, the columns of ``ardf`` are liste
 * ``qv_mean``      : float, spatially averaged meridional integrated vapor flux, in :math:`kg/(m \cdot s)`.
 
 
-Detecated Python script
+Dedicated Python script
 #######################
 
 You can use the ``scripts/detect_ARs.py`` or


### PR DESCRIPTION
A quick PR to amend a typo I noticed in one of the headings in the documentation. I assume it should instead say 'Dedicated' as per the equivalent headings on the pages for the other three main functionalities.

This was noticed whilst reviewing towards openjournals/joss-reviews#2407 but is a trivial change so has no real influence on the review.